### PR TITLE
prevent spurious empty key value by preventing parsing of empty string as a query string

### DIFF
--- a/lib/nurl.js
+++ b/lib/nurl.js
@@ -79,7 +79,7 @@ Url.prototype.getQueryParam = function(param, defaultValue) {
 };
 Url.prototype.getQueryParams = function() {
     var search = this.__getProperty('search');
-    return qs.parse(search ? search : '');
+    return search ? qs.parse(search) : {};
 };
 Url.prototype.getPathSegment = function(index) {
     var segments = this.getPathSegments();


### PR DESCRIPTION
currently, with node 0.3.1:

```
> require('nurl').parse('http://a.com/').setQueryParam('a', 'b').href
'http://a.com/?=&a=b'
```

after this change:

```
> require('nurl').parse('http://a.com/').setQueryParam('a', 'b').href
'http://a.com/?a=b'
```
