### PR TITLE
added setSearch function

### DIFF
--- a/lib/nurl.js
+++ b/lib/nurl.js
@@ -202,6 +202,11 @@ Url.prototype.setQueryParam = function(param, value) {
 	return createFromProperties(this.__setProperty('search', qs.stringify(params)));
 };
 
+Url.prototype.setSearch = function(search){
+    search = (search.substr(0,1) === '?') ? search.substr(1) : search;
+    return createFromProperties(this.__setProperty('search', search));
+};
+
 Url.prototype.mergeWith = function(url) {
 	if (typeof url.__getProperties != 'function') {
 		throw Error("Url.mergeWith must be passed a Url object");


### PR DESCRIPTION
If I want to override all query parameters. Currently I have to do it like this:
    url = new nurl.Url(
      url.getScheme(),
      url.getUser(),
      url.getPassword(),
      url.getHostname(),
      url.getPort(),
      url.getPathname(),
      "a=b&c=d",
      url.getHash()
    );

So to simplify this, it would be really handy to just pass a new search string.